### PR TITLE
Completed rename within code

### DIFF
--- a/bg.html
+++ b/bg.html
@@ -7,7 +7,7 @@
     <script src="jquery.min.js"></script>
   </head>
   <body>
-    fb-places-pro
+    FB Wiki's Facebook Editor Helper
     <div id="mapDiv" style="position:absolute; height:400px; width:400px"></div>
   </body>
 </html>

--- a/bg.js
+++ b/bg.js
@@ -12,11 +12,11 @@ chrome.tabs.onUpdated.addListener(function(id, info, tab){ // Listen for any cha
 
     if ( tab.status == "complete" ){
       if ( ON ){
-        console.log("Preparing to setup fb-places-pro! tab.id="+tab.id);
+        console.log("Preparing to setup the FB Wiki's Facebook Editor Helper! tab.id="+tab.id);
         chrome.tabs.executeScript(tab.id, { file: "jquery.min.js" }, function(){ // load jquery
           chrome.tabs.executeScript(tab.id, { file: "fbpp.js" });
         });
-      } else console.log("fb-places-pro is disabled.");
+      } else console.log("The FB Wiki's Facebook Editor Helper is currently disabled.");
     }
   }
 });

--- a/fbpp.js
+++ b/fbpp.js
@@ -1,4 +1,5 @@
-/* fb places pro
+/* FB Wiki's Facebook Editor Helper
+ *
  * This modifies the fb places editor to add new capabilities which will
  * hopefully boost the productivity of people using the editor
  *
@@ -18,7 +19,7 @@
  * input[name=seed]           the city id (although it's called a seed in one place, a cityId elsewhere)
  * .fwn.fcw                   the address and city in text
  *
- * See https://github.com/CombatChihuahua/fb-places-pro
+ * See https://github.com/fbwiki/editor-helper-chrome-extension
  */
 
 var fbpp = function(){

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
 
-  "name": "FB Wiki's Graph Editor Helper",
-  "short_name" : "GE Helper",
-  "description": "This is a tool made by the FB Wiki which is designed to assist with editing using Facebook's Graph Editor.",
+  "name": "FB Wiki's Facebook Editor Helper",
+  "short_name" : "Editor Helper",
+  "description": "This is a tool made by the FB Wiki which is designed to assist with editing using Facebook's Editor app.",
   "version": "0.1.1",
   "icons": { "128": "fbpp-128.png" },
 
@@ -20,7 +20,7 @@
   },
 
   "page_action": {
-    "default_title": "fb places pro",
+    "default_title": "FB Wiki's Facebook Editor Helper",
     "default_icon": "fbpp-32.png",
     "default_popup": "popup.html"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
 
-  "name": "fb-places-pro",
-  "short_name" : "fbpp",
-  "description": "This extension enhances the productivity of the fb places editor.",
+  "name": "FB Wiki's Graph Editor Helper",
+  "short_name" : "GE Helper",
+  "description": "This is a tool made by the FB Wiki which is designed to assist with editing using Facebook's Graph Editor.",
   "version": "0.1.1",
   "icons": { "128": "fbpp-128.png" },
 

--- a/popup.html
+++ b/popup.html
@@ -7,7 +7,7 @@
     <script src="jquery.min.js"></script>
   </head>
   <body>
-    fb-places-pro
+    FB Wiki's Facebook Editor Helper
     <div id="mapDiv" style="position:absolute; height:400px; width:400px"></div>
   </body>
 </html>


### PR DESCRIPTION
I have renamed all instances (I think) where it said '_fb-places-pro_' to the official name.

I have **not** upped the version in the `/manifest.json` file, I was going to leave that up to @MichelFloyd (can you also merge this pull request if you too agree with my changes? else let me know)

The Google Chrome app itself may or may not need updating too, not sure how much of this code is used on the app's website's description/name/etc.
