### PR TITLE
📚 Update the README to adhere to the (new) MarkDown specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-##Facebook Editor Bling (Chrome Extension) The **Editor Helper** (formerly
+## Facebook Editor Bling (Chrome Extension) The **Editor Helper** (formerly
 **_Facebook Places Pro_** *or* **_Graph Editor Helper_**, *dubbed* **_Facebook
 Editor Bling_** *by the original developer, Dr. Michel Floyd*) is a Google
 Chrome extension/tool designed to improve the speed and accuracy with which
 places can be edited using the [Facebook
 Editor](https://www.facebook.com/editor).
 
-###Install
+### Install
 The current production version of this extension is installable from the
 [Google Chrome
 Webstore](https://chrome.google.com/webstore/detail/fb-places-pro/imnppmbmlacllpppkbcnjfnadjikmpgi?hl=en-US)
 
-###FULL DOCUMENTATION
+### FULL DOCUMENTATION
 The full documentation can be found on Jason Friend's site [here](http://www.jasonfriend.me/facebookplaces/w/wiki:editor:community_chrome_extension).
 
 (The docs need to be moved to the fb wiki or put here on GitHub with the extension)
 
-###Other Browsers
+### Other Browsers
 If you want to help the FB Wiki bring this to other browsers, then please [let
 us know](http://www.fbwiki.com/#contact) and we can work together!
 
-###License
+### License
 This has an MIT License, for more details please see '/LICENSE' and
 [www.fbwiki.com/#legal](http://www.fbwiki.com/#legal). Please note that this is
 a fork of the original extensions repo which has since superceeded it.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## Facebook Editor Bling (Chrome Extension) The **Editor Helper** (formerly
+## Facebook Editor Bling (Chrome Extension) 
+The **Editor Helper** (formerly
 **_Facebook Places Pro_** *or* **_Graph Editor Helper_**, *dubbed* **_Facebook
 Editor Bling_** *by the original developer, Dr. Michel Floyd*) is a Google
 Chrome extension/tool designed to improve the speed and accuracy with which


### PR DESCRIPTION
GitHub is using a [formal specification for the MarkDown grammar](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown) starting March 2017, the current `README.md` does not adhere to this specification.